### PR TITLE
Seek for prev / getNearestTo

### DIFF
--- a/services/storage/api/src/main/java/services/storage/BidirectionalIterator.java
+++ b/services/storage/api/src/main/java/services/storage/BidirectionalIterator.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright ConsenSys Software Inc., 2023
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package services.storage;
+
+import java.util.Iterator;
+
+public interface BidirectionalIterator<T> extends Iterator<T> {
+  boolean hasPrevious();
+
+  T previous();
+}

--- a/services/storage/api/src/main/java/services/storage/KeyValueStorage.java
+++ b/services/storage/api/src/main/java/services/storage/KeyValueStorage.java
@@ -14,7 +14,6 @@
 package services.storage;
 
 import java.io.Closeable;
-import java.util.Iterator;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Predicate;
@@ -66,7 +65,7 @@ public interface KeyValueStorage extends Closeable {
    *     given key.
    * @throws StorageException problem encountered during the retrieval attempt.
    */
-  Optional<Iterator<KeyValuePair>> getNearestTo(byte[] key) throws StorageException;
+  Optional<BidirectionalIterator<KeyValuePair>> getNearestTo(byte[] key) throws StorageException;
 
   /**
    * Returns a stream of all keys and values.

--- a/services/storage/rocksdb/src/main/java/net/consensys/shomei/services/storage/rocksdb/RocksDBKeyValueSegment.java
+++ b/services/storage/rocksdb/src/main/java/net/consensys/shomei/services/storage/rocksdb/RocksDBKeyValueSegment.java
@@ -15,13 +15,13 @@ package net.consensys.shomei.services.storage.rocksdb;
 
 import static java.util.stream.Collectors.toUnmodifiableSet;
 
-import java.util.Iterator;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Predicate;
 import java.util.stream.Stream;
 
 import org.rocksdb.ReadOptions;
+import services.storage.BidirectionalIterator;
 import services.storage.KeyValueStorage;
 import services.storage.KeyValueStorageTransaction;
 import services.storage.SnappableKeyValueStorage;
@@ -57,7 +57,8 @@ public class RocksDBKeyValueSegment implements SnappableKeyValueStorage {
   }
 
   @Override
-  public Optional<Iterator<KeyValuePair>> getNearestTo(final byte[] key) throws StorageException {
+  public Optional<BidirectionalIterator<KeyValuePair>> getNearestTo(final byte[] key)
+      throws StorageException {
     return segment.getNearestTo(readOptions, key);
   }
 

--- a/services/storage/rocksdb/src/main/java/net/consensys/shomei/services/storage/rocksdb/RocksDBKeyValueSnapshot.java
+++ b/services/storage/rocksdb/src/main/java/net/consensys/shomei/services/storage/rocksdb/RocksDBKeyValueSnapshot.java
@@ -16,7 +16,6 @@ package net.consensys.shomei.services.storage.rocksdb;
 import static java.util.stream.Collectors.toUnmodifiableSet;
 
 import java.io.IOException;
-import java.util.Iterator;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -25,6 +24,7 @@ import java.util.stream.Stream;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import services.storage.BidirectionalIterator;
 import services.storage.KeyValueStorage;
 import services.storage.KeyValueStorageTransaction;
 import services.storage.StorageException;
@@ -53,7 +53,8 @@ public class RocksDBKeyValueSnapshot implements KeyValueStorage {
   }
 
   @Override
-  public Optional<Iterator<KeyValuePair>> getNearestTo(final byte[] key) throws StorageException {
+  public Optional<BidirectionalIterator<KeyValuePair>> getNearestTo(final byte[] key)
+      throws StorageException {
     return snapTx.getNearestTo(key);
   }
 

--- a/services/storage/rocksdb/src/main/java/net/consensys/shomei/services/storage/rocksdb/RocksDBSegmentedStorage.java
+++ b/services/storage/rocksdb/src/main/java/net/consensys/shomei/services/storage/rocksdb/RocksDBSegmentedStorage.java
@@ -18,7 +18,6 @@ import net.consensys.shomei.services.storage.rocksdb.configuration.RocksDBConfig
 
 import java.util.ArrayList;
 import java.util.EnumSet;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -50,6 +49,7 @@ import org.rocksdb.TransactionDBOptions;
 import org.rocksdb.WriteOptions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import services.storage.BidirectionalIterator;
 import services.storage.KeyValueStorage;
 import services.storage.KeyValueStorageTransaction;
 import services.storage.SnappableKeyValueStorage;
@@ -290,7 +290,7 @@ public class RocksDBSegmentedStorage implements AutoCloseable {
       return reference.get().hashCode();
     }
 
-    public Optional<Iterator<KeyValueStorage.KeyValuePair>> getNearestTo(
+    public Optional<BidirectionalIterator<KeyValueStorage.KeyValuePair>> getNearestTo(
         final ReadOptions readOptions, final byte[] key) {
       throwIfClosed();
 
@@ -300,7 +300,7 @@ public class RocksDBSegmentedStorage implements AutoCloseable {
 
         return Optional.of(iterator)
             .filter(AbstractRocksIterator::isValid)
-            .map(RocksDBIterator::createForPrev);
+            .map(RocksDBIterator::create);
       } catch (final Throwable t) {
         throw new StorageException(t);
       }

--- a/services/storage/rocksdb/src/main/java/net/consensys/shomei/services/storage/rocksdb/RocksDBTransaction.java
+++ b/services/storage/rocksdb/src/main/java/net/consensys/shomei/services/storage/rocksdb/RocksDBTransaction.java
@@ -13,7 +13,6 @@
 
 package net.consensys.shomei.services.storage.rocksdb;
 
-import java.util.Iterator;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Stream;
@@ -29,6 +28,7 @@ import org.rocksdb.Transaction;
 import org.rocksdb.WriteOptions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import services.storage.BidirectionalIterator;
 import services.storage.KeyValueStorage.KeyValuePair;
 import services.storage.KeyValueStorageTransaction;
 import services.storage.StorageException;
@@ -77,7 +77,7 @@ public class RocksDBTransaction implements KeyValueStorageTransaction, AutoClose
     }
   }
 
-  public Optional<Iterator<KeyValuePair>> getNearestTo(byte[] key) {
+  public Optional<BidirectionalIterator<KeyValuePair>> getNearestTo(byte[] key) {
     throwIfClosed();
 
     try {
@@ -86,7 +86,7 @@ public class RocksDBTransaction implements KeyValueStorageTransaction, AutoClose
 
       return Optional.of(iterator)
           .filter(AbstractRocksIterator::isValid)
-          .map(RocksDBIterator::createForPrev);
+          .map(RocksDBIterator::create);
     } catch (final Throwable t) {
       throw new StorageException(t);
     }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/ConsenSys/shomei/blob/master/CONTRIBUTING.md -->

## PR Description
add  getNearestTo method to KeyValueStorage in storage api 

implement getNearestTo using seekForPrev in rocksdb:
   KeyValueStorage 
   KeyValueSnapshot
   SnapshotTransaction 

fix defect where stream() and streamKeys() in RocksKeyValueSnapshot read from db instead of through the transaction

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.
