### PR TITLE
adds --rpc-http-host-allow-list to set up allowed hosts

### DIFF
--- a/services/rpc/server/src/main/java/net/consensys/shomei/rpc/server/JsonRpcService.java
+++ b/services/rpc/server/src/main/java/net/consensys/shomei/rpc/server/JsonRpcService.java
@@ -25,6 +25,7 @@ import net.consensys.shomei.trie.json.JsonTraceParser;
 
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.StringJoiner;
@@ -92,11 +93,13 @@ public class JsonRpcService extends AbstractVerticle {
   public JsonRpcService(
       final String rpcHttpHost,
       final Integer rpcHttpPort,
+      final Optional<List<String>> hostAllowList,
       final TrieLogObserver trieLogObserver,
       final WorldStateRepository worldStateStorage) {
     this.config = JsonRpcConfiguration.createDefault();
     config.setHost(rpcHttpHost);
     config.setPort(rpcHttpPort);
+    hostAllowList.ifPresent(config::setHostsAllowlist);
     this.rpcMethods = new HashMap<>();
     this.rpcMethods.putAll(
         mapOf(

--- a/shomei/src/main/java/net/consensys/shomei/Runner.java
+++ b/shomei/src/main/java/net/consensys/shomei/Runner.java
@@ -27,6 +27,8 @@ import net.consensys.shomei.storage.PersistedWorldStateRepository;
 import net.consensys.shomei.storage.WorldStateRepository;
 import net.consensys.shomei.worldview.ZkEvmWorldStateEntryPoint;
 
+import java.util.Optional;
+
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.binder.jvm.JvmGcMetrics;
 import io.micrometer.core.instrument.binder.jvm.JvmMemoryMetrics;
@@ -75,6 +77,7 @@ public class Runner {
         new JsonRpcService(
             jsonRpcOption.getRpcHttpHost(),
             jsonRpcOption.getRpcHttpPort(),
+            Optional.of(jsonRpcOption.getRpcHttpHostAllowList()),
             fullSyncDownloader,
             worldStateStorage);
   }

--- a/shomei/src/main/java/net/consensys/shomei/cli/option/JsonRpcOption.java
+++ b/shomei/src/main/java/net/consensys/shomei/cli/option/JsonRpcOption.java
@@ -13,6 +13,9 @@
 
 package net.consensys.shomei.cli.option;
 
+import java.util.Arrays;
+import java.util.List;
+
 import picocli.CommandLine;
 import picocli.CommandLine.Model.CommandSpec;
 import picocli.CommandLine.Spec;
@@ -35,6 +38,15 @@ public class JsonRpcOption {
 
   public static final int BESU_DEFAULT_JSON_RPC_PORT = 8545;
   public static final int SHOMEI_DEFAULT_JSON_RPC_PORT = 8888;
+  public static final List<String> SHOMEI_DEFAULT_JSON_RPC_HOST_ALLOW_LIST =
+      Arrays.asList("localhost", "127.0.0.1");
+
+  @CommandLine.Option(
+      names = {"--rpc-http-host-allow-list"},
+      paramLabel = "<ALLOW_HOSTS>",
+      description = "Hosts to accept state updates from (default: ${DEFAULT-VALUE})",
+      arity = "1")
+  private List<String> rpcHttpHostAllowList = SHOMEI_DEFAULT_JSON_RPC_HOST_ALLOW_LIST;
 
   @SuppressWarnings({"FieldCanBeFinal", "FieldMayBeFinal"}) // PicoCLI requires non-final Strings.
   @CommandLine.Option(
@@ -73,6 +85,10 @@ public class JsonRpcOption {
 
   public Integer getBesuRHttpPort() {
     return besuRHttpPort;
+  }
+
+  public List<String> getRpcHttpHostAllowList() {
+    return rpcHttpHostAllowList;
   }
 
   public String getRpcHttpHost() {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/ConsenSys/shomei/blob/master/CONTRIBUTING.md -->

## PR Description
Adds `--rpc-http-host-allow-list` option to set list of host to accept requests from. Defaults to `[localhost, 127.0.0.1]`

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.
