### PR TITLE
Fix for proof

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=2.2.1
+version=2.2.2-SNAPSHOT
 
 org.gradle.welcome=never
 

--- a/trie/src/main/java/net/consensys/shomei/trie/StoredNodeFactory.java
+++ b/trie/src/main/java/net/consensys/shomei/trie/StoredNodeFactory.java
@@ -145,6 +145,9 @@ public class StoredNodeFactory implements NodeFactory<Bytes> {
      * optimization for pruning, we can achieve an efficient and compact representation of the
      * sparse Merkle trie.
      */
+    if (Bytes32.ZERO.equals(hash)) {
+      return Optional.of(EmptyLeafNode.instance());
+    }
     return nodeLoader
         .getNode(location, hash)
         .or(


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/ConsenSys/shomei/blob/master/CONTRIBUTING.md -->

## PR Description

When we delete a leaf node (i.e., replace it with zero), we don't persist the modification and only change the hash in the parent. In this case, we see in the parent that the hash is empty, but we still try to read from the database to get the encoded byte for the proof, instead of realizing that the hash is empty and we don't need to read from the database. For tracing, it's not the same, because we return the hash and not the encoded byte.

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.
