### PR TITLE
add head metrics gauge

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -115,7 +115,7 @@ jobs:
           ./gradlew --no-daemon dockerTest
 
   buildArm64:
-    runs-on: [ ARM64, Linux, self-hosted ]
+    runs-on: [ besu-arm64 ]
     strategy:
       matrix:
         architecture: [ arm64 ]
@@ -173,7 +173,7 @@ jobs:
   publishDockerArm64:
     needs: buildArm64
     if: github.event_name == 'push'
-    runs-on: [ ARM64, Linux, self-hosted ]
+    runs-on: [ besu-arm64 ]
     env:
       architecture: "arm64"
       GRADLE_OPTS: "-Dorg.gradle.daemon=false -Dorg.gradle.parallel=true -Dorg.gradle.workers.max=2"

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -20,6 +20,7 @@ dependencies {
     implementation project(':crypto')
     implementation project(':services:storage:api')
     implementation project(':services:storage:rocksdb')
+    implementation project(':services:metrics')
 
     implementation 'org.hyperledger.besu.internal:trie'
     implementation 'org.hyperledger.besu.internal:core'

--- a/core/src/test/java/net/consensys/shomei/storage/ZkWorldStateArchiveTests.java
+++ b/core/src/test/java/net/consensys/shomei/storage/ZkWorldStateArchiveTests.java
@@ -111,7 +111,8 @@ public class ZkWorldStateArchiveTests {
             archive.getTrieLogManager(),
             archive.getTraceManager(),
             archive.getHeadWorldStateStorage(),
-            false, noopMetrics);
+            false,
+            noopMetrics);
 
     assertThat(zkWorldStateArchive.getCachedWorldState(0L).isPresent()).isFalse();
 
@@ -120,7 +121,8 @@ public class ZkWorldStateArchiveTests {
             archive.getTrieLogManager(),
             archive.getTraceManager(),
             archive.getHeadWorldStateStorage(),
-            true, noopMetrics);
+            true,
+            noopMetrics);
 
     assertThat(zkWorldStateArchive.getCachedWorldState(0L).isPresent()).isTrue();
   }

--- a/core/src/test/java/net/consensys/shomei/storage/ZkWorldStateArchiveTests.java
+++ b/core/src/test/java/net/consensys/shomei/storage/ZkWorldStateArchiveTests.java
@@ -16,6 +16,8 @@ package net.consensys.shomei.storage;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import net.consensys.shomei.exception.MissingTrieLogException;
+import net.consensys.shomei.metrics.MetricsService;
+import net.consensys.shomei.metrics.NoOpMetricsService;
 import net.consensys.shomei.observer.TrieLogObserver.TrieLogIdentifier;
 import net.consensys.shomei.trielog.PluginTrieLogLayer;
 import net.consensys.shomei.trielog.TrieLogLayerConverter;
@@ -33,6 +35,7 @@ public class ZkWorldStateArchiveTests {
   ZkWorldStateArchive archive = new ZkWorldStateArchive(new InMemoryStorageProvider());
   TrieLogLayerConverter converter = new TrieLogLayerConverter(archive.getHeadWorldStateStorage());
   ZkTrieLogFactory encoder = new ZkTrieLogFactory();
+  MetricsService noopMetrics = new NoOpMetricsService();
 
   @Test
   public void shouldDropWorldStatesFromHead() {
@@ -108,7 +111,7 @@ public class ZkWorldStateArchiveTests {
             archive.getTrieLogManager(),
             archive.getTraceManager(),
             archive.getHeadWorldStateStorage(),
-            false);
+            false, noopMetrics);
 
     assertThat(zkWorldStateArchive.getCachedWorldState(0L).isPresent()).isFalse();
 
@@ -117,7 +120,7 @@ public class ZkWorldStateArchiveTests {
             archive.getTrieLogManager(),
             archive.getTraceManager(),
             archive.getHeadWorldStateStorage(),
-            true);
+            true, noopMetrics);
 
     assertThat(zkWorldStateArchive.getCachedWorldState(0L).isPresent()).isTrue();
   }

--- a/services/metrics/build.gradle
+++ b/services/metrics/build.gradle
@@ -20,8 +20,8 @@ dependencies {
     implementation 'io.vertx:vertx-core'
     implementation 'io.vertx:vertx-web'
     implementation 'io.vertx:vertx-micrometer-metrics'
-    implementation 'io.micrometer:micrometer-core'
     implementation 'io.micrometer:micrometer-registry-prometheus'
+    api 'io.micrometer:micrometer-core'
 
 
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.8.1'

--- a/services/metrics/src/main/java/net/consensys/shomei/metrics/MetricsService.java
+++ b/services/metrics/src/main/java/net/consensys/shomei/metrics/MetricsService.java
@@ -14,13 +14,19 @@
 package net.consensys.shomei.metrics;
 
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Supplier;
 
 import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Tag;
 import io.vertx.core.Verticle;
 
-public interface MetricsService extends Verticle {
+public interface MetricsService {
 
   MeterRegistry getRegistry();
+
+  void addGauge(String name, String description, Iterable<Tag> tags, Supplier<Number> supplier);
+
+  interface VertxMetricsService extends MetricsService, Verticle {}
 
   class MetricsServiceProvider {
     private static final AtomicReference<MetricsService> METRICS_SERVICE = new AtomicReference<>();

--- a/services/metrics/src/main/java/net/consensys/shomei/metrics/NoOpMetricsService.java
+++ b/services/metrics/src/main/java/net/consensys/shomei/metrics/NoOpMetricsService.java
@@ -13,16 +13,15 @@
 
 package net.consensys.shomei.metrics;
 
+import java.util.function.Supplier;
+
 import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Tag;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
-import io.vertx.core.Context;
-import io.vertx.core.Promise;
-import io.vertx.core.Vertx;
 
 public class NoOpMetricsService implements MetricsService {
 
   private final MeterRegistry meterRegistry;
-  private Vertx vertx;
 
   public NoOpMetricsService() {
     this.meterRegistry = new SimpleMeterRegistry();
@@ -34,22 +33,11 @@ public class NoOpMetricsService implements MetricsService {
   }
 
   @Override
-  public Vertx getVertx() {
-    return vertx;
-  }
-
-  @Override
-  public void init(final Vertx vertx, final Context context) {
-    this.vertx = vertx;
-  }
-
-  @Override
-  public void start(final Promise<Void> startPromise) throws Exception {
-    // no-op
-  }
-
-  @Override
-  public void stop(final Promise<Void> stopPromise) throws Exception {
+  public void addGauge(
+      final String name,
+      final String description,
+      final Iterable<Tag> tags,
+      final Supplier<Number> supplier) {
     // no-op
   }
 }

--- a/services/metrics/src/main/java/net/consensys/shomei/metrics/PrometheusMetricsService.java
+++ b/services/metrics/src/main/java/net/consensys/shomei/metrics/PrometheusMetricsService.java
@@ -13,14 +13,19 @@
 
 package net.consensys.shomei.metrics;
 
+import java.util.function.Supplier;
+
+import io.micrometer.core.instrument.Gauge;
 import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Tag;
 import io.micrometer.prometheus.PrometheusConfig;
 import io.micrometer.prometheus.PrometheusMeterRegistry;
 import io.vertx.core.AbstractVerticle;
 import io.vertx.core.Promise;
 import io.vertx.ext.web.Router;
 
-public class PrometheusMetricsService extends AbstractVerticle implements MetricsService {
+public class PrometheusMetricsService extends AbstractVerticle
+    implements MetricsService.VertxMetricsService {
   private final PrometheusMeterRegistry prometheusMeterRegistry;
   private final String host;
   private final int port;
@@ -34,6 +39,20 @@ public class PrometheusMetricsService extends AbstractVerticle implements Metric
   @Override
   public MeterRegistry getRegistry() {
     return prometheusMeterRegistry;
+  }
+
+  @Override
+  public void addGauge(
+      final String name,
+      final String description,
+      final Iterable<Tag> tags,
+      final Supplier<Number> supplier) {
+
+    // Register a gauge to track this value
+    Gauge.builder(name, supplier)
+        .description(description)
+        .tags(tags)
+        .register(prometheusMeterRegistry);
   }
 
   @Override

--- a/shomei/src/main/java/net/consensys/shomei/Runner.java
+++ b/shomei/src/main/java/net/consensys/shomei/Runner.java
@@ -50,7 +50,7 @@ public class Runner {
   private final FullSyncDownloader fullSyncDownloader;
   private final JsonRpcService jsonRpcService;
 
-  private final MetricsService metricsService;
+  private final MetricsService.VertxMetricsService metricsService;
 
   private final ZkWorldStateArchive worldStateArchive;
 
@@ -103,9 +103,9 @@ public class Runner {
     HashProvider.setTrieHashFunction(hashFunctionOption.getHashFunction());
   }
 
-  private MetricsService setupMetrics(MetricsOption metricsOption) {
+  private MetricsService.VertxMetricsService setupMetrics(MetricsOption metricsOption) {
     // use prometheus as metrics service
-    MetricsService metricsService =
+    MetricsService.VertxMetricsService metricsService =
         new PrometheusMetricsService(
             metricsOption.getMetricsHttpHost(), metricsOption.getMetricsHttpPort());
     MeterRegistry meterRegistry = metricsService.getRegistry();


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/ConsenSys/shomei/blob/master/CONTRIBUTING.md -->

## PR Description
Add a metrics gauge tracking shomei head state: `shomei_blockchain_head`
e.g.:

```
$ curl -s localhost:9888/metrics|grep shomei
# HELP shomei_blockchain_head current chain head block number which corresponds to shomei state
# TYPE shomei_blockchain_head gauge
shomei_blockchain_head 257373.0


$ curl -s localhost:9888/metrics|grep shomei
# HELP shomei_blockchain_head current chain head block number which corresponds to shomei state
# TYPE shomei_blockchain_head gauge
shomei_blockchain_head 257642.0
```

also removes the expectation that a MetricsService is a vertx verticle..

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->
#99 

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.
