### PR TITLE
add publishVersion to maven central publishing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,8 +125,10 @@ jobs:
           DISTRIBUTION: 'adopt'
            
       - name: Publish on maven central
+        with:
+          publish-version: ${{ needs.assemble.outputs.publish-version }}
         run: |
-          ./gradlew clean build assemble publish jreleaserFullRelease
+          ./gradlew -Pversion=${{ needs.build.outputs.publish-version }} clean build assemble publish jreleaserFullRelease
         env:
           JRELEASER_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           JRELEASER_GITHUB_USERNAME: ${{ github.actor }}
@@ -277,7 +279,7 @@ jobs:
           tags: ${{ steps.docker-metadata.outputs.tags }}
 
   release:
-    # if: startsWith(github.ref, 'refs/tags/')
+    if: startsWith(github.ref, 'refs/tags/')
     needs:
       - assemble
       - unitTests


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/ConsenSys/shomei/blob/master/CONTRIBUTING.md -->

## PR Description
add calculated publishVersion to maven central publish build.  otherwise we get 2.x-develop releases

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.
