### PR TITLE
Fix/shomei decode historical trielogs

### DIFF
--- a/core/src/main/java/net/consensys/shomei/trielog/TrieLogLayerConverter.java
+++ b/core/src/main/java/net/consensys/shomei/trielog/TrieLogLayerConverter.java
@@ -43,8 +43,8 @@ public class TrieLogLayerConverter {
 
   final WorldStateStorage headWorldStateStorage;
 
-  public TrieLogLayerConverter(final WorldStateStorage worldStateStorage) {
-    this.headWorldStateStorage = worldStateStorage;
+  public TrieLogLayerConverter(final WorldStateStorage headWorldStateStorage) {
+    this.headWorldStateStorage = headWorldStateStorage;
   }
 
   public TrieLogLayer decodeTrieLog(final RLPInput input) {
@@ -89,7 +89,7 @@ public class TrieLogLayerConverter {
                 .map(FlattenedLeaf::leafIndex);
       } else {
         input.enterList();
-        final PriorAccount priorAccount = preparePriorTrieLogAccount(accountKey, input);
+        final PriorAccount priorAccount = preparePriorTrieLogAccount(accountKey, input, wss);
         maybeAccountIndex = priorAccount.index;
         final ZkAccount newAccountValue =
             TrieLogLayer.nullOrValue(
@@ -183,10 +183,6 @@ public class TrieLogLayerConverter {
   }
 
   record PriorAccount(ZkAccount account, Bytes32 evmStorageRoot, Optional<Long> index) {}
-
-  public PriorAccount preparePriorTrieLogAccount(final AccountKey accountKey, final RLPInput in) {
-    return preparePriorTrieLogAccount(accountKey, in , headWorldStateStorage);
-  }
 
   public PriorAccount preparePriorTrieLogAccount(final AccountKey accountKey, final RLPInput in, final WorldStateStorage wss) {
 

--- a/core/src/main/java/net/consensys/shomei/trielog/TrieLogLayerConverter.java
+++ b/core/src/main/java/net/consensys/shomei/trielog/TrieLogLayerConverter.java
@@ -41,13 +41,17 @@ public class TrieLogLayerConverter {
 
   private static final Logger LOG = LoggerFactory.getLogger(TrieLogLayerConverter.class);
 
-  final WorldStateStorage worldStateStorage;
+  final WorldStateStorage headWorldStateStorage;
 
   public TrieLogLayerConverter(final WorldStateStorage worldStateStorage) {
-    this.worldStateStorage = worldStateStorage;
+    this.headWorldStateStorage = worldStateStorage;
   }
 
   public TrieLogLayer decodeTrieLog(final RLPInput input) {
+    return decodeTrieLog(input, headWorldStateStorage);
+  }
+
+  public TrieLogLayer decodeTrieLog(final RLPInput input, WorldStateStorage wss) {
 
     TrieLogLayer trieLogLayer = new TrieLogLayer();
 
@@ -80,7 +84,7 @@ public class TrieLogLayerConverter {
       if (input.nextIsNull()) {
         input.skipNext();
         maybeAccountIndex =
-            worldStateStorage
+            wss
                 .getFlatLeaf(WRAP_ACCOUNT.apply(accountKey.accountHash()))
                 .map(FlattenedLeaf::leafIndex);
       } else {
@@ -122,7 +126,7 @@ public class TrieLogLayerConverter {
                   maybeAccountIndex
                       .flatMap(
                           index -> {
-                            return new StorageTrieRepositoryWrapper(index, worldStateStorage, null)
+                            return new StorageTrieRepositoryWrapper(index, wss, null)
                                   .getFlatLeaf(storageSlotKey.slotHash())
                                   .map(FlattenedLeaf::leafValue)
                                   .map(UInt256::fromBytes);
@@ -181,11 +185,15 @@ public class TrieLogLayerConverter {
   record PriorAccount(ZkAccount account, Bytes32 evmStorageRoot, Optional<Long> index) {}
 
   public PriorAccount preparePriorTrieLogAccount(final AccountKey accountKey, final RLPInput in) {
+    return preparePriorTrieLogAccount(accountKey, in , headWorldStateStorage);
+  }
+
+  public PriorAccount preparePriorTrieLogAccount(final AccountKey accountKey, final RLPInput in, final WorldStateStorage wss) {
 
     final ZkAccount oldAccountValue;
 
     final Optional<FlattenedLeaf> flatLeaf =
-        worldStateStorage.getFlatLeaf(WRAP_ACCOUNT.apply(accountKey.accountHash()));
+        wss.getFlatLeaf(WRAP_ACCOUNT.apply(accountKey.accountHash()));
 
 
     if (in.nextIsNull() && flatLeaf.isEmpty()) {

--- a/services/rpc/server/src/main/java/net/consensys/shomei/rpc/server/method/RollupGetVirtualZkEVMStateMerkleProofV1.java
+++ b/services/rpc/server/src/main/java/net/consensys/shomei/rpc/server/method/RollupGetVirtualZkEVMStateMerkleProofV1.java
@@ -75,7 +75,8 @@ public class RollupGetVirtualZkEVMStateMerkleProofV1 implements JsonRpcMethod {
       }
 
       // do not have it in cache
-      if (worldStateArchive.getCachedWorldState(parentBlockNumber).isEmpty()) {
+      final var optWorldState = worldStateArchive.getCachedWorldState(parentBlockNumber);
+      if (optWorldState.isEmpty()) {
         return new ShomeiJsonRpcErrorResponse(
             requestContext.getRequest().getId(),
             RpcErrorType.INVALID_PARAMS,
@@ -90,7 +91,8 @@ public class RollupGetVirtualZkEVMStateMerkleProofV1 implements JsonRpcMethod {
 
       // Decode the trielog
       final TrieLogLayer trieLogLayer =
-          worldStateArchive.getTrieLogLayerConverter().decodeTrieLog(RLP.input(trieLogBytes));
+          worldStateArchive.getTrieLogLayerConverter().decodeTrieLog(
+              RLP.input(trieLogBytes), optWorldState.get().getZkEvmWorldStateStorage());
 
       // Apply the virtual trielog and generate the trace
       // This generates a trace without persisting the state

--- a/services/rpc/server/src/test/java/net/consensys/shomei/rpc/server/method/RollupGetVirtualZkEVMStateMerkleProofV1Test.java
+++ b/services/rpc/server/src/test/java/net/consensys/shomei/rpc/server/method/RollupGetVirtualZkEVMStateMerkleProofV1Test.java
@@ -148,7 +148,7 @@ public class RollupGetVirtualZkEVMStateMerkleProofV1Test {
 
     // Mock the trielog layer converter
     when(worldStateArchive.getTrieLogLayerConverter()).thenReturn(trieLogLayerConverter);
-    when(trieLogLayerConverter.decodeTrieLog(any())).thenReturn(trieLogLayer);
+    when(trieLogLayerConverter.decodeTrieLog(any(), any())).thenReturn(trieLogLayer);
 
     // Mock virtual trace generation
     final List<List<Trace>> mockTraces = List.of(List.of());


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/ConsenSys/shomei/blob/master/CONTRIBUTING.md -->

## PR Description
Add a trielog decode overload that enables zktrielogs to be built against historical state.  Use this overload in rollup_getVirtualZkEVMStateMerkleProofV1 when decoding trielogs from `eth_simulateV1`

Relates to #136 

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes which `WorldStateStorage` is consulted during trielog decoding, affecting account/storage old-value verification and virtual proof generation. Risk is mainly correctness-related for historical/virtual block processing; limited surface area but can cause decoding failures or incorrect proofs if miswired.
> 
> **Overview**
> Fixes historical/virtual trielog decoding by allowing `TrieLogLayerConverter` to decode against a caller-provided `WorldStateStorage` instead of always using the head state.
> 
> Updates `rollup_getVirtualZkEVMStateMerkleProofV1` to pass the cached parent block’s `ZkEvmWorldStateStorage` when decoding the `eth_simulateV1` trielog, and adjusts the associated test to mock the new overload.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 97a2266de2619a6b35747549f3d637e9437a3c26. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->