### PR TITLE
quick swag at timestamp-in-trielog

### DIFF
--- a/services/rpc/common/src/main/java/net/consensys/shomei/rpc/model/TrieLogElement.java
+++ b/services/rpc/common/src/main/java/net/consensys/shomei/rpc/model/TrieLogElement.java
@@ -16,6 +16,8 @@ package net.consensys.shomei.rpc.model;
 import net.consensys.shomei.observer.TrieLogObserver.TrieLogIdentifier;
 import net.consensys.shomei.trie.json.JsonTraceParser;
 
+import java.util.OptionalLong;
+
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -26,6 +28,7 @@ import org.apache.tuweni.bytes.Bytes32;
 public class TrieLogElement {
 
   private Long blockNumber;
+  private OptionalLong timestamp;
   private Bytes32 blockHash;
   private boolean isInitialSync;
   private String trieLog;
@@ -35,12 +38,14 @@ public class TrieLogElement {
   @JsonCreator
   public TrieLogElement(
       @JsonProperty("blockNumber") final Long blockNumber,
+      @JsonProperty("timestamp") final OptionalLong timestamp,
       @JsonProperty("blockHash")
           @JsonDeserialize(using = JsonTraceParser.Bytes32Deserializer.class)
           final Bytes32 blockHash,
       @JsonProperty("trieLog") final String trieLog,
       @JsonProperty("syncing") final Boolean syncing) {
     this.blockNumber = blockNumber;
+    this.timestamp = timestamp;
     this.blockHash = blockHash;
     this.isInitialSync = syncing != null && syncing;
     this.trieLog = trieLog;
@@ -48,6 +53,10 @@ public class TrieLogElement {
 
   public Long blockNumber() {
     return blockNumber;
+  }
+
+  public OptionalLong timestamp() {
+    return timestamp;
   }
 
   public Bytes32 blockHash() {
@@ -71,6 +80,8 @@ public class TrieLogElement {
     return "SendRawTrieLogParameter{"
         + "blockNumber="
         + blockNumber
+        + "timestamp="
+        + timestamp.orElse(0L)
         + ", blockHash="
         + blockHash
         + ", isInitialSync="


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/ConsenSys/shomei/blob/master/CONTRIBUTING.md -->

## PR Description

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new `timestamp` field to an RPC model, which can impact JSON (de)serialization and backward/forward compatibility with clients/servers if Jackson `OptionalLong` support or field presence differs.
> 
> **Overview**
> Extends `TrieLogElement` to carry an optional `timestamp` parsed from the RPC payload, exposing it via a new accessor and including it in `toString()`.
> 
> This changes the JSON-creator constructor signature to accept `timestamp` and stores it alongside existing block metadata.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1c597ee992f1412ec07b37c251cf6bf07c0186a0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->