### PR TITLE
Speculative/timestamp in trielog

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,7 @@ groupVal=io.consensys.protocols.shomei
 version=3.2.1
 
 besuVersion=26.2.0
-shomeiPluginVersion=1.0.4-rc1
+shomeiPluginVersion=1.0.5
 
 org.gradle.welcome=never
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,7 @@ groupVal=io.consensys.protocols.shomei
 version=3.2.1
 
 besuVersion=26.2.0
-shomeiPluginVersion=1.0.1
+shomeiPluginVersion=1.0.4-rc1
 
 org.gradle.welcome=never
 

--- a/services/rpc/client/src/main/java/net/consensys/shomei/rpc/client/BesuSimulateClient.java
+++ b/services/rpc/client/src/main/java/net/consensys/shomei/rpc/client/BesuSimulateClient.java
@@ -17,10 +17,10 @@ import net.consensys.shomei.rpc.client.model.SimulateV1Response;
 
 import java.security.NoSuchAlgorithmException;
 import java.security.SecureRandom;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.OptionalLong;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
@@ -76,7 +76,9 @@ public class BesuSimulateClient {
   }
 
   public CompletableFuture<String> simulateTransaction(
-      final long parentBlockNumber, final String transactionRlp) {
+      final long parentBlockNumber,
+      final String transactionRlp,
+      final OptionalLong timestamp) {
 
     final CompletableFuture<String> completableFuture = new CompletableFuture<>();
     final int requestId = RANDOM.nextInt();
@@ -86,9 +88,10 @@ public class BesuSimulateClient {
       final Transaction transaction =
           TransactionDecoder.decodeOpaqueBytes(transactionBytes, EncodingContext.POOLED_TRANSACTION);
 
-      // Create block overrides with parent block number
-      final Map<String, String> blockOverrides =
-          Collections.singletonMap("number", "0x" + Long.toHexString(parentBlockNumber + 1));
+      // Create block overrides with block number and optional timestamp
+      final Map<String, String> blockOverrides = new HashMap<>();
+      blockOverrides.put("number", "0x" + Long.toHexString(parentBlockNumber + 1));
+      timestamp.ifPresent(ts -> blockOverrides.put("time", "0x" + Long.toHexString(ts)));
 
       // Extract transaction fields for the call
       final String chainId =

--- a/services/rpc/client/src/test/java/net/consensys/shomei/rpc/client/BesuSimulateClientTest.java
+++ b/services/rpc/client/src/test/java/net/consensys/shomei/rpc/client/BesuSimulateClientTest.java
@@ -25,6 +25,7 @@ import static org.mockito.Mockito.when;
 import net.consensys.shomei.rpc.client.model.SimulateV1Response;
 
 import java.math.BigInteger;
+import java.util.OptionalLong;
 import java.util.concurrent.CompletableFuture;
 
 import io.vertx.core.AsyncResult;
@@ -151,7 +152,8 @@ public class BesuSimulateClientTest {
     final String txRlp =
         TransactionEncoder.encodeOpaqueBytes(eip1559Tx, EncodingContext.POOLED_TRANSACTION)
             .toHexString();
-    final CompletableFuture<String> future = client.simulateTransaction(7L, txRlp);
+    final CompletableFuture<String> future =
+        client.simulateTransaction(7L, txRlp, OptionalLong.empty());
 
     final String trieLog = future.get();
     assertThat(trieLog).isEqualTo(MOCK_TRIELOG);
@@ -177,7 +179,8 @@ public class BesuSimulateClientTest {
     final String txRlp =
         TransactionEncoder.encodeOpaqueBytes(legacyTx, EncodingContext.POOLED_TRANSACTION)
             .toHexString();
-    final CompletableFuture<String> future = client.simulateTransaction(7L, txRlp);
+    final CompletableFuture<String> future =
+        client.simulateTransaction(7L, txRlp, OptionalLong.empty());
 
     final String trieLog = future.get();
     assertThat(trieLog).isEqualTo(MOCK_TRIELOG);

--- a/services/rpc/common/src/main/java/net/consensys/shomei/rpc/model/TrieLogElement.java
+++ b/services/rpc/common/src/main/java/net/consensys/shomei/rpc/model/TrieLogElement.java
@@ -28,7 +28,7 @@ import org.apache.tuweni.bytes.Bytes32;
 public class TrieLogElement {
 
   private Long blockNumber;
-  private OptionalLong timestamp;
+  private OptionalLong timestamp = OptionalLong.empty();
   private Bytes32 blockHash;
   private boolean isInitialSync;
   private String trieLog;
@@ -38,14 +38,14 @@ public class TrieLogElement {
   @JsonCreator
   public TrieLogElement(
       @JsonProperty("blockNumber") final Long blockNumber,
-      @JsonProperty("timestamp") final OptionalLong timestamp,
+      @JsonProperty("timestamp") final Long timestamp,
       @JsonProperty("blockHash")
           @JsonDeserialize(using = JsonTraceParser.Bytes32Deserializer.class)
           final Bytes32 blockHash,
       @JsonProperty("trieLog") final String trieLog,
       @JsonProperty("syncing") final Boolean syncing) {
     this.blockNumber = blockNumber;
-    this.timestamp = timestamp;
+    this.timestamp = timestamp != null ? OptionalLong.of(timestamp) : OptionalLong.empty();
     this.blockHash = blockHash;
     this.isInitialSync = syncing != null && syncing;
     this.trieLog = trieLog;
@@ -77,10 +77,10 @@ public class TrieLogElement {
 
   @Override
   public String toString() {
-    return "SendRawTrieLogParameter{"
+    return "TrieLogElement{"
         + "blockNumber="
         + blockNumber
-        + "timestamp="
+        + ", timestamp="
         + timestamp.orElse(0L)
         + ", blockHash="
         + blockHash

--- a/services/rpc/common/src/main/java/net/consensys/shomei/rpc/model/TrieLogElement.java
+++ b/services/rpc/common/src/main/java/net/consensys/shomei/rpc/model/TrieLogElement.java
@@ -16,6 +16,8 @@ package net.consensys.shomei.rpc.model;
 import net.consensys.shomei.observer.TrieLogObserver.TrieLogIdentifier;
 import net.consensys.shomei.trie.json.JsonTraceParser;
 
+import java.util.OptionalLong;
+
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -26,6 +28,7 @@ import org.apache.tuweni.bytes.Bytes32;
 public class TrieLogElement {
 
   private Long blockNumber;
+  private OptionalLong timestamp;
   private Bytes32 blockHash;
   private boolean isInitialSync;
   private String trieLog;
@@ -35,12 +38,14 @@ public class TrieLogElement {
   @JsonCreator
   public TrieLogElement(
       @JsonProperty("blockNumber") final Long blockNumber,
+      @JsonProperty("timestamp") final OptionalLong timestamp,
       @JsonProperty("blockHash")
           @JsonDeserialize(using = JsonTraceParser.Bytes32Deserializer.class)
           final Bytes32 blockHash,
       @JsonProperty("trieLog") final String trieLog,
       @JsonProperty("syncing") final Boolean syncing) {
     this.blockNumber = blockNumber;
+    this.timestamp = timestamp;
     this.blockHash = blockHash;
     this.isInitialSync = syncing != null && syncing;
     this.trieLog = trieLog;
@@ -48,6 +53,10 @@ public class TrieLogElement {
 
   public Long blockNumber() {
     return blockNumber;
+  }
+
+  public OptionalLong timestamp() {
+    return timestamp;
   }
 
   public Bytes32 blockHash() {
@@ -71,6 +80,8 @@ public class TrieLogElement {
     return "SendRawTrieLogParameter{"
         + "blockNumber="
         + blockNumber
+        + "timestamp="
+        + timestamp.orElse(0L)
         + ", blockHash="
         + blockHash
         + ", isInitialSync="

--- a/services/rpc/server/src/main/java/net/consensys/shomei/rpc/server/method/RollupGetVirtualZkEVMStateMerkleProofV1.java
+++ b/services/rpc/server/src/main/java/net/consensys/shomei/rpc/server/method/RollupGetVirtualZkEVMStateMerkleProofV1.java
@@ -62,6 +62,7 @@ public class RollupGetVirtualZkEVMStateMerkleProofV1 implements JsonRpcMethod {
     final long blockNumber = param.getBlockNumber();
     final long parentBlockNumber = blockNumber - 1;
     final String transactionRlp = param.getTransaction();
+    final var timestamp = param.getTimestamp();
 
 
     try {
@@ -85,7 +86,7 @@ public class RollupGetVirtualZkEVMStateMerkleProofV1 implements JsonRpcMethod {
       // Call eth_simulateV1 to get the trielog for the virtual block
       // Simulate on top of parentBlockNumber state to build virtual block at blockNumber
       final String trieLogHex =
-          besuSimulateClient.simulateTransaction(parentBlockNumber, transactionRlp).join();
+          besuSimulateClient.simulateTransaction(parentBlockNumber, transactionRlp, timestamp).join();
       final Bytes trieLogBytes = Bytes.fromHexString(trieLogHex);
 
       // Decode the trielog

--- a/services/rpc/server/src/main/java/net/consensys/shomei/rpc/server/model/RollupGetVirtualZkEvmStateMerkleProofV0Parameter.java
+++ b/services/rpc/server/src/main/java/net/consensys/shomei/rpc/server/model/RollupGetVirtualZkEvmStateMerkleProofV0Parameter.java
@@ -12,6 +12,8 @@
  */
 package net.consensys.shomei.rpc.server.model;
 
+import java.util.OptionalLong;
+
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
@@ -21,12 +23,16 @@ public class RollupGetVirtualZkEvmStateMerkleProofV0Parameter {
 
   private final String transaction;
 
+  private final OptionalLong timestamp;
+
   @JsonCreator
   public RollupGetVirtualZkEvmStateMerkleProofV0Parameter(
       @JsonProperty("blockNumber") final String blockNumber,
-      @JsonProperty("transaction") final String transaction) {
+      @JsonProperty("transaction") final String transaction,
+      @JsonProperty("timestamp") final Long timestamp) {
     this.blockNumber = blockNumber;
     this.transaction = transaction;
+    this.timestamp = timestamp != null ? OptionalLong.of(timestamp) : OptionalLong.empty();
   }
 
   public long getBlockNumber() {
@@ -37,6 +43,10 @@ public class RollupGetVirtualZkEvmStateMerkleProofV0Parameter {
     return transaction;
   }
 
+  public OptionalLong getTimestamp() {
+    return timestamp;
+  }
+
   @Override
   public String toString() {
     return "RollupGetVirtualZkEvmStateMerkleProofV0Parameter{"
@@ -45,6 +55,8 @@ public class RollupGetVirtualZkEvmStateMerkleProofV0Parameter {
         + ", transaction='"
         + transaction
         + '\''
+        + ", timestamp="
+        + timestamp
         + '}';
   }
 }

--- a/services/rpc/server/src/test/java/net/consensys/shomei/rpc/server/method/RollupGetVirtualZkEVMStateMerkleProofV1Test.java
+++ b/services/rpc/server/src/test/java/net/consensys/shomei/rpc/server/method/RollupGetVirtualZkEVMStateMerkleProofV1Test.java
@@ -134,7 +134,7 @@ public class RollupGetVirtualZkEVMStateMerkleProofV1Test {
     final String testTxRlp = createTestTransactionRlp();
 
     // Mock the BesuSimulateClient to return a trielog
-    when(besuSimulateClient.simulateTransaction(eq(7L), eq(testTxRlp)))
+    when(besuSimulateClient.simulateTransaction(eq(7L), eq(testTxRlp), any()))
         .thenReturn(CompletableFuture.completedFuture(mockTrieLogHex));
 
     // Mock world state archive behavior
@@ -173,7 +173,7 @@ public class RollupGetVirtualZkEVMStateMerkleProofV1Test {
     when(worldStateArchive.getCachedWorldState(7L)).thenReturn(Optional.of(mockZkWorldState));
 
     // Mock simulation failure
-    when(besuSimulateClient.simulateTransaction(anyLong(), anyString()))
+    when(besuSimulateClient.simulateTransaction(anyLong(), anyString(), any()))
         .thenReturn(
             CompletableFuture.failedFuture(new RuntimeException("Simulation failed")));
 
@@ -195,7 +195,7 @@ public class RollupGetVirtualZkEVMStateMerkleProofV1Test {
 
     // Mock simulation returning a detailed error from eth_simulateV1
     final String detailedErrorMessage = "eth_simulateV1 error [code=-32000]: insufficient funds";
-    when(besuSimulateClient.simulateTransaction(anyLong(), anyString()))
+    when(besuSimulateClient.simulateTransaction(anyLong(), anyString(), any()))
         .thenReturn(CompletableFuture.failedFuture(new RuntimeException(detailedErrorMessage)));
 
     final JsonRpcRequestContext request = request(8L, createTestTransactionRlp());
@@ -214,7 +214,7 @@ public class RollupGetVirtualZkEVMStateMerkleProofV1Test {
             "rollup_getVirtualZkEVMStateMerkleProofV1",
             new Object[] {
                 new RollupGetVirtualZkEvmStateMerkleProofV0Parameter(
-                    String.valueOf(blockNumber), transactionRlp)
+                    String.valueOf(blockNumber), transactionRlp, null)
             }));
   }
 

--- a/trie/src/main/java/net/consensys/shomei/trie/json/JsonTraceParser.java
+++ b/trie/src/main/java/net/consensys/shomei/trie/json/JsonTraceParser.java
@@ -71,7 +71,7 @@ public class JsonTraceParser {
                   public void serialize(
                       Hash node, JsonGenerator jsonGen, SerializerProvider serProv)
                       throws IOException {
-                    jsonGen.writeString(node.toHexString());
+                    jsonGen.writeString(node.getBytes().toHexString());
                   }
                 }),
         new SimpleModule()


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/ConsenSys/shomei/blob/master/CONTRIBUTING.md -->

## PR Description

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds an optional `timestamp` parameter that flows through the `rollup_getVirtualZkEVMStateMerkleProofV1` path into `eth_simulateV1` block overrides, which can change simulated state/results. Also tweaks JSON serialization of `Hash`, which could affect trace/log output compatibility.
> 
> **Overview**
> Enables *speculative virtual block simulation* with an optional `timestamp`: the RPC parameter model now accepts `timestamp`, `RollupGetVirtualZkEVMStateMerkleProofV1` passes it through, and `BesuSimulateClient.simulateTransaction` conditionally includes a `time` override in the `eth_simulateV1` request.
> 
> Extends trie log payload modeling by adding `timestamp` to `TrieLogElement`, updates related tests/mocks for the new client/server method signature, bumps `shomeiPluginVersion` to `1.0.5`, and adjusts `JsonTraceParser` to serialize `Hash` via `getBytes().toHexString()`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 773ae6737c3dbf148907c43636cb0ac24b6c5049. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->