### PR TITLE
optimise docker image size

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,14 @@
+.git
+.github
+.gradle
+.idea
+*.iml
+*.log
+**/build
+!build
+!build/distributions
+!build/distributions/*.tar.gz
+tmp
+out
+target
+node_modules

--- a/.dockerignore
+++ b/.dockerignore
@@ -4,8 +4,7 @@
 .idea
 *.iml
 *.log
-**/build
-!build
+**/build/**
 !build/distributions
 !build/distributions/*.tar.gz
 tmp

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,7 @@ jobs:
         uses: Consensys/github-actions/java-setup-gradle@main
         with:
           DISTRIBUTION: 'adopt'
+          VERSION: '21'
 
       - name: Determine Shomei version
         id: project-version
@@ -93,6 +94,7 @@ jobs:
         uses: Consensys/github-actions/java-setup-gradle@main
         with:
           DISTRIBUTION: 'adopt'
+          VERSION: '21'
 
       - name: Download workspace
         uses: actions/download-artifact@v4
@@ -135,6 +137,7 @@ jobs:
         uses: Consensys/github-actions/java-setup-gradle@main
         with:
           DISTRIBUTION: 'adopt'
+          VERSION: '21'
 
       - name: Publish on maven central
         env:

--- a/docker/openjdk-21/Dockerfile
+++ b/docker/openjdk-21/Dockerfile
@@ -1,5 +1,6 @@
+# syntax=docker/dockerfile:1.7
 
-FROM ubuntu:24.04
+FROM eclipse-temurin:21-jre-noble
 ARG VERSION="dev"
 ARG BUILD_DATE
 ARG VCS_REF
@@ -18,23 +19,18 @@ ARG TAR_FILE
 # Validate that the TAR_FILE argument is provided
 RUN if [ -z "$TAR_FILE" ]; then echo "TAR_FILE build argument is required" && exit 1; fi
 
-RUN apt-get update  && \
-    apt-get install --no-install-recommends -q --assume-yes ca-certificates ca-certificates-java jq openjdk-21-jdk-headless libjemalloc-dev \
-    curl wget net-tools netcat-traditional adduser iputils-ping && \
-    apt-get clean && \
-    rm -rf /var/lib/apt/lists/*  
-    
-RUN adduser --disabled-password --gecos "" --home /opt/shomei shomei && \
-    chown shomei:shomei /opt/shomei && chmod 0755 /opt/shomei
+RUN groupadd --system shomei && \
+    useradd --system --gid shomei --home-dir /opt/shomei --create-home --shell /usr/sbin/nologin shomei && \
+    chmod 0755 /opt/shomei
 
-USER shomei
 WORKDIR /opt/shomei
 
-COPY --chown=shomei:shomei ${TAR_FILE} /tmp/shomei.tar.gz
 # Extract the tar.gz file and rename the directory
-RUN mkdir -p /opt/shomei && \
+RUN --mount=type=bind,source=${TAR_FILE},target=/tmp/shomei.tar.gz,ro \
     tar -xzf /tmp/shomei.tar.gz -C /opt/shomei --strip-components=1 && \
-    rm /tmp/shomei.tar.gz && chown -R shomei:shomei /opt/shomei
+    chown -R shomei:shomei /opt/shomei
+
+USER shomei
 
 # Expose services ports
 # 8888 HTTP JSON-RPC
@@ -46,7 +42,6 @@ ENV OTEL_RESOURCE_ATTRIBUTES="service.name=shomei,service.version=$VERSION"
 ENV OLDPATH="${PATH}"
 ENV PATH="/opt/shomei/bin:${OLDPATH}"
 
-HEALTHCHECK --start-period=5s --interval=5s --timeout=1s --retries=10 CMD bash -c "[ -f /tmp/pid ]"
+HEALTHCHECK --start-period=5s --interval=5s --timeout=1s --retries=10 CMD bash -c ':</dev/tcp/127.0.0.1/8888'
 
 ENTRYPOINT ["/opt/shomei/bin/shomei"]
-

--- a/docker/openjdk-21/Dockerfile
+++ b/docker/openjdk-21/Dockerfile
@@ -19,8 +19,8 @@ ARG TAR_FILE
 # Validate that the TAR_FILE argument is provided
 RUN if [ -z "$TAR_FILE" ]; then echo "TAR_FILE build argument is required" && exit 1; fi
 
-RUN groupadd --system shomei && \
-    useradd --system --gid shomei --home-dir /opt/shomei --create-home --shell /usr/sbin/nologin shomei && \
+RUN groupadd --gid 1001 shomei && \
+    useradd --uid 1001 --gid 1001 --home-dir /opt/shomei --create-home --shell /usr/sbin/nologin shomei && \
     chmod 0755 /opt/shomei
 
 WORKDIR /opt/shomei

--- a/docker/tests/01/goss_wait.yaml
+++ b/docker/tests/01/goss_wait.yaml
@@ -1,12 +1,6 @@
 ---
 # runtime docker tests for interfaces & ports
-#port:
-#  tcp:8888:
-#    listening: true
-#    ip:
-#      - 0.0.0.0
 command:
   port_8888_open:
-    exec: "nc -zv 127.0.0.1 8888"  # Replace with your IP and port
+    exec: "bash -c ':</dev/tcp/127.0.0.1/8888'"
     exit-status: 0
-

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 # configuring groupVal rather than group prevents a circular dep in mavenPublishing
 groupVal=io.consensys.protocols.shomei
 
-version=3.2.3
+version=3.2.4
 
 besuVersion=26.2.0
 shomeiPluginVersion=1.0.6


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/ConsenSys/shomei/blob/master/CONTRIBUTING.md -->

## PR Description
Optimises docker image

- docker image ls: 1.46GB -> 845MB
- docker inspect .Size: 599,618,694 -> 301,988,200 bytes

I tested the new image aginst linea e2e test stack it passed the tests



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Switches the production Docker base image and install/extraction strategy, which can change runtime behavior and health checking even though app code is untouched. CI/runtime validation updates reduce but don’t eliminate risk of environment-specific regressions.
> 
> **Overview**
> Optimizes the Docker build by adding a `.dockerignore`, switching the runtime image to `eclipse-temurin:21-jre-noble`, and extracting the distribution tarball via BuildKit bind-mount instead of copying/apt-installing dependencies.
> 
> Updates container hardening/ops behavior by creating a fixed UID/GID `shomei` user and changing the Docker `HEALTHCHECK` (and goss test) to validate TCP connectivity on `127.0.0.1:8888` rather than relying on a PID file.
> 
> CI is adjusted to explicitly use Java `21` in all Gradle jobs, and `gradle.properties` bumps the version from `3.2.3` to `3.2.4`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 88a1ce9d43866fd89416c3b53eefd11f62e95e1f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->